### PR TITLE
Add external_id parameter for AWS credential chain

### DIFF
--- a/test/sql/aws_secret_external_id.test
+++ b/test/sql/aws_secret_external_id.test
@@ -1,0 +1,30 @@
+# name: test/sql/aws_secret_external_id.test
+# description: test aws secrets with external_id parameter
+# group: [aws]
+
+require no_extension_autoloading "EXPECTED: Test relies on explicit INSTALL and LOAD"
+
+require aws
+
+require httpfs
+
+# Create a secret with external_id parameter
+statement ok
+CREATE SECRET s3_cred (
+    TYPE s3, 
+    PROVIDER credential_chain,
+    chain 'sts',
+    assume_role_arn 'arn:aws:iam::123456789012:role/test-role',
+    external_id 'test-external-id',
+    region 'us-west-2'
+)
+
+# Verify the secret was created
+query I
+SELECT secret_string FROM duckdb_secrets(redact=false) where name='s3_cred';
+----
+<REGEX>:.*endpoint=s3.amazonaws.com.*
+
+# Clean up
+statement ok
+DROP SECRET IF EXISTS s3_cred


### PR DESCRIPTION
This change adds support for the external_id parameter when using the AWS credential chain with the STS assume role provider.